### PR TITLE
Initial draft

### DIFF
--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,13 +1,13 @@
 org_name: nullstone
-name: aws-fargate-task
-friendly_name: Fargate Task
-description: Creates a Fargate application that is run on-demand.
+name: aws-ecs-task
+friendly_name: ECS Task
+description: Creates an ECS application that can be run on demand.
 category: app
 subcategory: container
 provider_types:
     - aws
 platform: ecs
-subplatform: fargate
+subplatform: ec2
 type: ""
 appCategories: []
 is_public: true

--- a/.nullstone/module.yml
+++ b/.nullstone/module.yml
@@ -1,0 +1,13 @@
+org_name: nullstone
+name: aws-fargate-task
+friendly_name: Fargate Task
+description: Creates a Fargate application that is run on-demand.
+category: app
+subcategory: container
+provider_types:
+    - aws
+platform: ecs
+subplatform: fargate
+type: ""
+appCategories: []
+is_public: true

--- a/README.md
+++ b/README.md
@@ -1,3 +1,28 @@
 # aws-ecs-task
 
-Nullstone app module to create a runnable ECS task.
+This is a Nullstone application module that provides the same workflow as other container apps in Nullstone.
+However, because it is only a task, it does not create infrastructure for a long-running service.
+Instead, the task is executed manually using the outputs from this module.
+
+## Push
+
+This module enables support for automated artifact pushes.
+This process utilizes credentials from `image_pusher` output to push to the ECR repository. 
+
+## Deploy
+
+This module enables support for automated deploys.
+This process utilizes credentials from `deployer` output to perform commands against AWS:
+- create deployment record in Nullstone
+- Register new ECS Task Definition
+- Deregister old ECS Task Definition
+
+## Service Name
+
+By contract, an `app:container/aws/ecs:*` module must contain `service_name` output.
+Since there is no service in this module, this output is set to `""` to signal to consumers (e.g. Nullstone CLI) that there is no service.
+
+## Load Balancers/Service Port
+
+Since this module is a task and has no long-running service, it does not support attaching load balancers or any other ingress capabilities.
+Additionally, this module provides no configuration for `service_port` since there is no long-running communication.

--- a/README.md
+++ b/README.md
@@ -1,2 +1,3 @@
-# aws-fargate-task
-Nullstone app module to create a runnable Fargate task.
+# aws-ecs-task
+
+Nullstone app module to create a runnable ECS task.

--- a/app.tf
+++ b/app.tf
@@ -1,0 +1,20 @@
+data "ns_app_env" "this" {
+  stack_id = data.ns_workspace.this.stack_id
+  app_id   = data.ns_workspace.this.block_id
+  env_id   = data.ns_workspace.this.env_id
+}
+
+locals {
+  app_version = data.ns_app_env.this.version
+}
+
+locals {
+  app_metadata = tomap({
+    // Inject app metadata into capabilities here (e.g. security_group_name, role_name)
+    security_group_id  = aws_security_group.this.id
+    role_name          = aws_iam_role.task.name
+    main_container     = local.main_container_name
+    log_group_name     = module.logs.name
+    internal_subdomain = ""
+  })
+}

--- a/aws.tf
+++ b/aws.tf
@@ -1,0 +1,2 @@
+data "aws_region" "this" {}
+data "aws_caller_identity" "current" {}

--- a/capabilities.tf
+++ b/capabilities.tf
@@ -1,0 +1,72 @@
+// This file is replaced by code-generation using 'capabilities.tf.tmpl'
+// This file helps app module creators define a contract for what types of capability outputs are supported.
+locals {
+  capabilities = {
+    env = [
+      {
+        name  = ""
+        value = ""
+      }
+    ]
+
+    secrets = [
+      {
+        name  = ""
+        value = ""
+      }
+    ]
+
+    // private_urls follows a wonky syntax so that we can send all capability outputs into the merge module
+    // Terraform requires that all members be of type list(map(any))
+    // They will be flattened into list(string) when we output from this module
+    private_urls = [
+      {
+        url = ""
+      }
+    ]
+
+    // public_urls follows a wonky syntax so that we can send all capability outputs into the merge module
+    // Terraform requires that all members be of type list(map(any))
+    // They will be flattened into list(string) when we output from this module
+    public_urls = [
+      {
+        url = ""
+      }
+    ]
+
+    log_configurations = [
+      {
+        logDriver = "awslogs"
+        options = {
+          "awslogs-region"        = data.aws_region.this.name
+          "awslogs-group"         = module.logs.name
+          "awslogs-stream-prefix" = local.block_name
+        }
+      }
+    ]
+
+    // capabilities can attach mount points to pull/push data from/to the main container
+    // The name of each mount point will be added to the task as a volume, then mounted in the main container
+    mount_points = [
+      {
+        name = "volume-name"
+        path = "/path/on/main/disk"
+      }
+    ]
+
+    // sidecars allow capabilities to attach additional containers to the service
+    sidecars = [
+      {
+        name         = ""
+        image        = ""
+        essential    = false
+        portMappings = [{ protocol = "tcp", containerPort = 0, hostPort = 0 }]
+        environment  = [{ name = "", value = "" }]
+        secrets      = [{ name = "", valueFrom = "" }]
+        mountPoints  = [{ sourceVolume = "", containerPath = "" }]
+        volumesFrom  = [{ sourceContainer = "" }]
+        dependsOn    = [{ containerName = "", condition = "" }]
+      }
+    ]
+  }
+}

--- a/capabilities.tf.tmpl
+++ b/capabilities.tf.tmpl
@@ -1,0 +1,35 @@
+{{ range . -}}
+provider "ns" {
+  capability_id = {{ .Id }}
+  alias         = "cap_{{ .Id }}"
+}
+
+module "{{ .TfModuleName }}" {
+  source  = "{{ .Source }}/any"
+  {{ if (ne .SourceVersion "latest") }}version = "{{ .SourceVersion }}"{{ end }}
+
+  app_metadata = local.app_metadata
+
+  {{- range $key, $value := .Variables }}
+  {{ if not $value.Unused -}}
+  {{ $key }} = jsondecode({{ $value.Value | to_json_string }})
+  {{- end }}{{ end }}
+
+  providers = {
+    ns = ns.cap_{{ .Id}}
+  }
+}
+{{ end }}
+module "caps" {
+  source  = "nullstone-modules/cap-merge/ns"
+  modules = local.modules
+}
+
+locals {
+  modules       = [
+{{- range $index, $element := .ExceptNeedsDestroyed.TfModuleAddrs -}}
+{{ if $index }}, {{ end }}{{ $element }}
+{{- end -}}
+]
+  capabilities  = module.caps.outputs
+}

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,0 +1,24 @@
+data "ns_connection" "cluster" {
+  name     = "cluster"
+  type     = "cluster/aws-fargate"
+  contract = "cluster/aws/ecs:fargate"
+}
+
+data "ns_connection" "network" {
+  name     = "network"
+  type     = "network/aws"
+  contract = "network/aws/vpc"
+  via      = data.ns_connection.cluster.name
+}
+
+locals {
+  vpc_id         = data.ns_connection.network.outputs.vpc_id
+  private_cidrs  = data.ns_connection.network.outputs.private_cidrs
+  public_cidrs   = data.ns_connection.network.outputs.public_cidrs
+  cluster_name   = data.ns_connection.cluster.outputs.cluster_name
+  deployers_name = data.ns_connection.cluster.outputs.deployers_name
+}
+
+data "aws_ecs_cluster" "cluster" {
+  cluster_name = local.cluster_name
+}

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,10 +1,12 @@
 data "ns_connection" "cluster" {
   name     = "cluster"
+  type     = "cluster/aws-ecs"
   contract = "cluster/aws/ecs:ec2"
 }
 
 data "ns_connection" "network" {
   name     = "network"
+  type     = "network/aws"
   contract = "network/aws/vpc"
   via      = data.ns_connection.cluster.name
 }

--- a/cluster.tf
+++ b/cluster.tf
@@ -1,12 +1,10 @@
 data "ns_connection" "cluster" {
   name     = "cluster"
-  type     = "cluster/aws-fargate"
-  contract = "cluster/aws/ecs:fargate"
+  contract = "cluster/aws/ecs:ec2"
 }
 
 data "ns_connection" "network" {
   name     = "network"
-  type     = "network/aws"
   contract = "network/aws/vpc"
   via      = data.ns_connection.cluster.name
 }

--- a/deployer.tf
+++ b/deployer.tf
@@ -1,0 +1,39 @@
+// ECS requires the user/role that initiates a deployment
+//   to have iam:PassRole access to the execution role
+// This grants the deployer user access to this service's execution role
+// This is necessary for us to execute `nullstone deploy` on the CLI
+
+resource "aws_iam_user" "deployer" {
+  name = "deployer-${local.resource_name}"
+  tags = local.tags
+}
+
+resource "aws_iam_access_key" "deployer" {
+  user = aws_iam_user.deployer.name
+}
+
+// Add deployer to deployers group defined in the cluster
+// This allows the deployer user to perform common operations on the cluster
+resource "aws_iam_user_group_membership" "deployers" {
+  user   = aws_iam_user.deployer.name
+  groups = [local.deployers_name]
+}
+
+resource "aws_iam_user_policy" "deployer" {
+  #bridgecrew:skip=CKV_AWS_40: Skipping `IAM policies attached only to groups or roles reduces management complexity`; Adding a role or group would increase complexity
+  user   = aws_iam_user.deployer.name
+  policy = data.aws_iam_policy_document.deployer.json
+}
+
+data "aws_iam_policy_document" "deployer" {
+  statement {
+    sid     = "AllowPassRoleToServiceRoles"
+    effect  = "Allow"
+    actions = ["iam:PassRole"]
+
+    resources = [
+      aws_iam_role.execution.arn,
+      aws_iam_role.task.arn,
+    ]
+  }
+}

--- a/encryption.tf
+++ b/encryption.tf
@@ -1,0 +1,64 @@
+resource "aws_kms_alias" "this" {
+  name          = "alias/${local.resource_name}"
+  target_key_id = aws_kms_key.this.id
+}
+
+resource "aws_kms_key" "this" {
+  description         = "Encryption key for service ${local.resource_name}"
+  enable_key_rotation = true
+  is_enabled          = true
+  tags                = local.tags
+  policy              = data.aws_iam_policy_document.encryption_key.json
+}
+
+data "aws_iam_policy_document" "encryption_key" {
+  #bridgecrew:skip=CKV_AWS_109: Skipping "Permissions management without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
+  #bridgecrew:skip=CKV_AWS_111: Skipping "Write IAM policies without constraints". False positive as this is attached as a key policy and is implicitly constrained by the key.
+  statement {
+    sid       = "Enable IAM User permissions"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:*"]
+
+    principals {
+      type        = "AWS"
+      identifiers = ["arn:aws:iam::${data.aws_caller_identity.current.account_id}:root"]
+    }
+  }
+
+  statement {
+    sid       = "Enable Cloudwatch Log encryption"
+    effect    = "Allow"
+    resources = ["*"]
+    actions = [
+      "kms:Encrypt*",
+      "kms:Decrypt*",
+      "kms:ReEncrypt*",
+      "kms:GenerateDataKey*",
+      "kms:Describe*"
+    ]
+
+    principals {
+      type        = "Service"
+      identifiers = ["logs.${data.aws_region.this.name}.amazonaws.com"]
+    }
+
+    condition {
+      test     = "ArnEquals"
+      variable = "kms:EncryptionContext:aws:logs:arn"
+      values   = ["arn:aws:logs:${data.aws_region.this.name}:${data.aws_caller_identity.current.account_id}:*"]
+    }
+  }
+
+  statement {
+    sid       = "Enable App Decrypt secrets"
+    effect    = "Allow"
+    resources = ["*"]
+    actions   = ["kms:Decrypt"]
+
+    principals {
+      type        = "AWS"
+      identifiers = [aws_iam_role.execution.arn]
+    }
+  }
+}

--- a/execution.tf
+++ b/execution.tf
@@ -1,0 +1,58 @@
+resource "aws_iam_role" "execution" {
+  name               = "execution-${local.resource_name}"
+  tags               = local.tags
+  assume_role_policy = data.aws_iam_policy_document.execution-assume.json
+}
+
+data "aws_iam_policy_document" "execution-assume" {
+  statement {
+    sid     = "AllowECSAssume"
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy_attachment" "execution-managed" {
+  role       = aws_iam_role.execution.name
+  policy_arn = "arn:aws:iam::aws:policy/service-role/AmazonECSTaskExecutionRolePolicy"
+}
+
+resource "aws_iam_role_policy" "execution" {
+  role   = aws_iam_role.execution.id
+  policy = data.aws_iam_policy_document.execution.json
+}
+
+locals {
+  // These are used to generate an IAM policy statement to allow the app to read the secrets
+  secret_arns                = [for as in aws_secretsmanager_secret.app_secret : as.arn]
+  secret_statement_resources = length(local.secret_arns) > 0 ? [local.secret_arns] : []
+}
+
+data "aws_iam_policy_document" "execution" {
+  statement {
+    sid       = "AllowPassRoleToECS"
+    effect    = "Allow"
+    actions   = ["iam:PassRole"]
+    resources = [aws_iam_role.execution.arn]
+  }
+
+  dynamic "statement" {
+    for_each = local.secret_statement_resources
+
+    content {
+      sid       = "AllowReadSecrets"
+      effect    = "Allow"
+      resources = statement.value
+
+      actions = [
+        "secretsmanager:GetSecretValue",
+        "kms:Decrypt"
+      ]
+    }
+  }
+}

--- a/logs.tf
+++ b/logs.tf
@@ -1,0 +1,21 @@
+module "logs" {
+  source = "nullstone-modules/logs/aws"
+
+  name              = local.resource_name
+  tags              = local.tags
+  enable_log_reader = true
+  retention_in_days = 90
+  kms_key_arn       = aws_kms_alias.this.arn
+}
+
+locals {
+  log_configuration = {
+    logDriver = "awslogs"
+    options = {
+      "awslogs-region"        = data.aws_region.this.name
+      "awslogs-group"         = module.logs.name
+      "awslogs-stream-prefix" = local.block_name
+    }
+  }
+  log_provider = "cloudwatch"
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -1,0 +1,24 @@
+terraform {
+  required_providers {
+    ns = {
+      source = "nullstone-io/ns"
+    }
+  }
+}
+
+data "ns_workspace" "this" {}
+
+// Generate a random suffix to ensure uniqueness of resources
+resource "random_string" "resource_suffix" {
+  length  = 5
+  lower   = true
+  upper   = false
+  numeric = false
+  special = false
+}
+
+locals {
+  tags          = data.ns_workspace.this.tags
+  block_name    = data.ns_workspace.this.block_name
+  resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
+}

--- a/nullstone.tf
+++ b/nullstone.tf
@@ -21,4 +21,5 @@ locals {
   tags          = data.ns_workspace.this.tags
   block_name    = data.ns_workspace.this.block_name
   resource_name = "${data.ns_workspace.this.block_ref}-${random_string.resource_suffix.result}"
+  env_name      = data.ns_workspace.this.env_name
 }

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,0 +1,99 @@
+output "region" {
+  value       = data.aws_region.this.name
+  description = "string ||| The region where the ECS container resides."
+}
+
+output "cluster_arn" {
+  value       = data.aws_ecs_cluster.cluster.arn
+  description = "string ||| "
+}
+
+output "log_provider" {
+  value       = local.log_provider
+  description = "string ||| "
+}
+
+output "log_group_name" {
+  value       = module.logs.name
+  description = "string ||| "
+}
+
+output "log_reader" {
+  value       = module.logs.reader
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
+  sensitive   = true
+}
+
+output "image_repo_name" {
+  value       = try(aws_ecr_repository.this[0].name, "")
+  description = "string ||| "
+}
+
+output "image_repo_url" {
+  value       = try(aws_ecr_repository.this[0].repository_url, "")
+  description = "string ||| "
+}
+
+output "image_pusher" {
+  value = {
+    name       = aws_iam_user.image_pusher.name
+    access_key = aws_iam_access_key.image_pusher.id
+    secret_key = aws_iam_access_key.image_pusher.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to push images."
+
+  sensitive = true
+}
+
+output "deployer" {
+  value = {
+    name       = aws_iam_user.deployer.name
+    access_key = aws_iam_access_key.deployer.id
+    secret_key = aws_iam_access_key.deployer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy ECS services."
+
+  sensitive = true
+}
+
+output "service_image" {
+  value       = "${local.service_image}:${local.app_version}"
+  description = "string ||| "
+}
+
+output "task_family" {
+  value       = aws_ecs_task_definition.this.family
+  description = "string ||| "
+}
+
+output "main_container_name" {
+  value       = local.container_definition.name
+  description = "string ||| The name of the container definition for the main service container"
+}
+
+output "service_security_group_id" {
+  value       = aws_security_group.this.id
+  description = "string ||| "
+}
+
+output "private_urls" {
+  value       = local.private_urls
+  description = "list(string) ||| A list of URLs only accessible inside the network"
+}
+
+output "public_urls" {
+  value       = local.public_urls
+  description = "list(string) ||| A list of URLs accessible to the public"
+}
+
+output "private_hosts" {
+  value       = local.private_hosts
+  description = "list(string) ||| A list of Hostnames only accessible inside the network"
+}
+
+output "public_hosts" {
+  value       = local.public_hosts
+  description = "list(string) ||| A list of Hostnames accessible to the public"
+}

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,37 +1,11 @@
 output "region" {
   value       = data.aws_region.this.name
-  description = "string ||| The region where the ECS container resides."
-}
-
-output "cluster_arn" {
-  value       = data.aws_ecs_cluster.cluster.arn
-  description = "string ||| "
-}
-
-output "log_provider" {
-  value       = local.log_provider
-  description = "string ||| "
-}
-
-output "log_group_name" {
-  value       = module.logs.name
-  description = "string ||| "
-}
-
-output "log_reader" {
-  value       = module.logs.reader
-  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
-  sensitive   = true
-}
-
-output "image_repo_name" {
-  value       = try(aws_ecr_repository.this[0].name, "")
-  description = "string ||| "
+  description = "string ||| The region where the ECS task resides."
 }
 
 output "image_repo_url" {
-  value       = try(aws_ecr_repository.this[0].repository_url, "")
-  description = "string ||| "
+  value       = aws_ecr_repository.this.repository_url
+  description = "string ||| The URL of the ECR repository."
 }
 
 output "image_pusher" {
@@ -46,26 +20,9 @@ output "image_pusher" {
   sensitive = true
 }
 
-output "deployer" {
-  value = {
-    name       = aws_iam_user.deployer.name
-    access_key = aws_iam_access_key.deployer.id
-    secret_key = aws_iam_access_key.deployer.secret
-  }
-
-  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy ECS services."
-
-  sensitive = true
-}
-
-output "service_image" {
-  value       = "${local.service_image}:${local.app_version}"
-  description = "string ||| "
-}
-
-output "task_family" {
-  value       = aws_ecs_task_definition.this.family
-  description = "string ||| "
+output "service_name" {
+  value       = ""
+  description = "string ||| This is an empty string because there is no service for a task."
 }
 
 output "main_container_name" {
@@ -73,9 +30,42 @@ output "main_container_name" {
   description = "string ||| The name of the container definition for the main service container"
 }
 
-output "service_security_group_id" {
+output "task_arn" {
+  value       = aws_ecs_task_definition.this.arn
+  description = "string ||| The AWS ARN of the app task definition."
+}
+
+output "app_security_group_id" {
   value       = aws_security_group.this.id
-  description = "string ||| "
+  description = "string ||| The ID of the security group attached to the app."
+}
+
+output "deployer" {
+  value = {
+    name       = aws_iam_user.deployer.name
+    access_key = aws_iam_access_key.deployer.id
+    secret_key = aws_iam_access_key.deployer.secret
+  }
+
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to deploy the ECS task."
+
+  sensitive = true
+}
+
+output "log_provider" {
+  value       = local.log_provider
+  description = "string ||| The name of the log provider containing application logs."
+}
+
+output "log_group_name" {
+  value       = module.logs.name
+  description = "string ||| The name of the cloudwatch log group containing application logs."
+}
+
+output "log_reader" {
+  value       = module.logs.reader
+  description = "object({ name: string, access_key: string, secret_key: string }) ||| An AWS User with explicit privilege to read logs from Cloudwatch."
+  sensitive   = true
 }
 
 output "private_urls" {

--- a/pusher.tf
+++ b/pusher.tf
@@ -1,0 +1,42 @@
+resource "aws_iam_user" "image_pusher" {
+  name = "image-pusher-${local.resource_name}"
+  tags = local.tags
+}
+
+resource "aws_iam_access_key" "image_pusher" {
+  user = aws_iam_user.image_pusher.name
+}
+
+resource "aws_iam_user_policy" "image_pusher" {
+  #bridgecrew:skip=CKV_AWS_40: Skipping `IAM policies attached only to groups or roles reduces management complexity`; Adding a role or group would increase complexity
+  name   = "AllowECRPush"
+  user   = aws_iam_user.image_pusher.name
+  policy = data.aws_iam_policy_document.image_pusher.json
+}
+
+data "aws_iam_policy_document" "image_pusher" {
+  statement {
+    sid    = "AllowPushPull"
+    effect = "Allow"
+
+    // The actions listed are necessary to perform actions to push ECR images
+    actions = [
+      "ecr:GetDownloadUrlForLayer",
+      "ecr:BatchGetImage",
+      "ecr:BatchCheckLayerAvailability",
+      "ecr:PutImage",
+      "ecr:InitiateLayerUpload",
+      "ecr:UploadLayerPart",
+      "ecr:CompleteLayerUpload"
+    ]
+
+    resources = [aws_ecr_repository.this.arn]
+  }
+
+  statement {
+    sid       = "AllowAuthorization"
+    effect    = "Allow"
+    actions   = ["ecr:GetAuthorizationToken"]
+    resources = ["*"]
+  }
+}

--- a/repository.tf
+++ b/repository.tf
@@ -1,0 +1,20 @@
+locals {
+  service_image = aws_ecr_repository.this.repository_url
+}
+
+// This is a bit odd - we're creating a repository for every environment
+// We need to find a better way to do this
+resource "aws_ecr_repository" "this" {
+  name                 = local.resource_name
+  tags                 = local.tags
+  image_tag_mutability = "IMMUTABLE"
+
+  image_scanning_configuration {
+    scan_on_push = true
+  }
+
+  encryption_configuration {
+    encryption_type = "KMS"
+    kms_key         = aws_kms_key.this.arn
+  }
+}

--- a/secrets.tf
+++ b/secrets.tf
@@ -1,0 +1,35 @@
+locals {
+  // We use `local.secret_keys` to create secret resources
+  // If we used `length(local.capabilities.secrets)`,
+  //   terraform would complain about not knowing count of the resource until after apply
+  // This is because the name of secrets isn't computed in the modules; only the secret value
+  raw_secret_keys = [for secret in lookup(local.capabilities, "secrets", []) : secret["name"]]
+  secret_keys     = can(nonsensitive(local.raw_secret_keys)) ? toset(nonsensitive(local.raw_secret_keys)) : toset(local.raw_secret_keys)
+  cap_secrets     = { for secret in try(local.capabilities.secrets, []) : secret["name"] => secret["value"] }
+
+  // app_secrets is prepared in the form [{ name = "", valueFrom = "<arn>" }, ...] for injection into ECS services
+  app_secrets = [for key in local.secret_keys : { name = key, valueFrom = aws_secretsmanager_secret.app_secret[key].arn }]
+}
+
+resource "aws_secretsmanager_secret" "app_secret" {
+  for_each = local.secret_keys
+
+  name_prefix = "${local.block_name}/${each.value}/"
+  tags        = local.tags
+  kms_key_id  = aws_kms_alias.this.arn
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}
+
+resource "aws_secretsmanager_secret_version" "app_secret" {
+  for_each = local.secret_keys
+
+  secret_id     = aws_secretsmanager_secret.app_secret[each.value].id
+  secret_string = local.cap_secrets[each.value]
+
+  lifecycle {
+    create_before_destroy = true
+  }
+}

--- a/security-group.tf
+++ b/security-group.tf
@@ -1,0 +1,46 @@
+resource "aws_security_group" "this" {
+  name        = local.resource_name
+  vpc_id      = local.vpc_id
+  tags        = merge(local.tags, { Name = local.resource_name })
+  description = "Managed by Terraform"
+}
+
+resource "aws_security_group_rule" "this-dns-tcp-to-world" {
+  description       = "Allow service to communicate with any nameserver over TCP"
+  security_group_id = aws_security_group.this.id
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 53
+  to_port           = 53
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "this-dns-udp-to-world" {
+  description       = "Allow service to communicate with any nameserver over UDP"
+  security_group_id = aws_security_group.this.id
+  type              = "egress"
+  protocol          = "udp"
+  from_port         = 53
+  to_port           = 53
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "this-https-to-world" {
+  description       = "Allow service to communicate with any server over HTTPS"
+  security_group_id = aws_security_group.this.id
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 443
+  to_port           = 443
+  cidr_blocks       = ["0.0.0.0/0"]
+}
+
+resource "aws_security_group_rule" "this-http-to-private-subnets" {
+  description       = "Allow this service to communicate with other services on the network over HTTP"
+  security_group_id = aws_security_group.this.id
+  type              = "egress"
+  protocol          = "tcp"
+  from_port         = 80
+  to_port           = 80
+  cidr_blocks       = local.private_cidrs
+}

--- a/sidecars.tf
+++ b/sidecars.tf
@@ -1,0 +1,27 @@
+locals {
+  sidecars = lookup(local.capabilities, "sidecars", [])
+
+  // Using jsondecode because all map values must be of the same type
+  addl_container_defs = [for s in local.sidecars : {
+    name      = s.name
+    image     = s.image
+    essential = tobool(lookup(s, "essential", false))
+    portMappings = [for mapping in jsondecode(lookup(s, "portMappings", "[]")) : {
+      protocol      = mapping.protocol
+      containerPort = tonumber(mapping.containerPort)
+      hostPort      = tonumber(mapping.hostPort)
+    }]
+    environment = jsondecode(lookup(s, "environment", "[]"))
+    secrets     = jsondecode(lookup(s, "secrets", "[]"))
+    mountPoints = jsondecode(lookup(s, "mountPoints", "[]"))
+    volumesFrom = jsondecode(lookup(s, "volumesFrom", "[]"))
+    healthCheck = jsondecode(lookup(s, "healthCheck", "null"))
+    dependsOn   = jsondecode(lookup(s, "dependsOn", "[]"))
+
+    logConfiguration = local.log_configuration
+  }]
+
+  // If a sidecar takes over the service_port, we will configure the load balancer against that container instead of "main"
+  sidecars_owns_service_port = { for s in local.sidecars : s.name => tobool(lookup(s, "owns_service_port", false)) }
+  lb_container_name          = try(compact([for name, owns in local.sidecars_owns_service_port : (owns == true ? name : "")])[0], "main")
+}

--- a/task.tf
+++ b/task.tf
@@ -10,9 +10,9 @@ locals {
   env_vars = [for k, v in merge(local.standard_env_vars, var.service_env_vars) : { name = k, value = v }]
 
   container_definition = {
-    name      = local.main_container_name
-    image     = "${local.service_image}:${local.app_version}"
-    essential = true
+    name         = local.main_container_name
+    image        = "${local.service_image}:${local.app_version}"
+    essential    = true
     portMappings = []
 
     environment = concat(local.env_vars, try(local.capabilities.env, []))
@@ -42,6 +42,8 @@ resource "aws_ecs_task_definition" "this" {
 
     content {
       name = volume.key
+
+      host_path = volume.value.host_path
 
       dynamic "efs_volume_configuration" {
         for_each = length(volume.value.efs_volume) > 0 ? tomap({ "1" = jsondecode(volume.value.efs_volume) }) : tomap({})

--- a/task.tf
+++ b/task.tf
@@ -1,6 +1,6 @@
 locals {
   standard_env_vars = tomap({
-    NULLSTONE_ENV           = data.ns_workspace.this.env_name
+    NULLSTONE_ENV           = local.env_name
     NULLSTONE_PUBLIC_HOSTS  = join(",", local.public_hosts)
     NULLSTONE_PRIVATE_HOSTS = join(",", local.private_hosts)
   })
@@ -30,11 +30,11 @@ resource "aws_ecs_task_definition" "this" {
   cpu                      = var.service_cpu
   memory                   = var.service_memory
   network_mode             = "awsvpc"
-  requires_compatibilities = ["FARGATE"]
+  requires_compatibilities = ["EC2"]
   execution_role_arn       = aws_iam_role.execution.arn
   depends_on               = [aws_iam_role_policy.execution]
   container_definitions    = jsonencode(concat([local.container_definition], local.addl_container_defs))
-  tags                     = data.ns_workspace.this.tags
+  tags                     = local.tags
   task_role_arn            = aws_iam_role.task.arn
 
   dynamic "volume" {

--- a/task.tf
+++ b/task.tf
@@ -1,0 +1,96 @@
+locals {
+  standard_env_vars = tomap({
+    NULLSTONE_ENV           = data.ns_workspace.this.env_name
+    NULLSTONE_PUBLIC_HOSTS  = join(",", local.public_hosts)
+    NULLSTONE_PRIVATE_HOSTS = join(",", local.private_hosts)
+  })
+
+  main_container_name = "main"
+
+  env_vars = [for k, v in merge(local.standard_env_vars, var.service_env_vars) : { name = k, value = v }]
+
+  container_definition = {
+    name      = local.main_container_name
+    image     = "${local.service_image}:${local.app_version}"
+    essential = true
+    portMappings = []
+
+    environment = concat(local.env_vars, try(local.capabilities.env, []))
+    secrets     = local.app_secrets
+
+    mountPoints = local.mount_points
+    volumesFrom = []
+
+    logConfiguration = local.log_configuration
+  }
+}
+
+resource "aws_ecs_task_definition" "this" {
+  family                   = local.resource_name
+  cpu                      = var.service_cpu
+  memory                   = var.service_memory
+  network_mode             = "awsvpc"
+  requires_compatibilities = ["FARGATE"]
+  execution_role_arn       = aws_iam_role.execution.arn
+  depends_on               = [aws_iam_role_policy.execution]
+  container_definitions    = jsonencode(concat([local.container_definition], local.addl_container_defs))
+  tags                     = data.ns_workspace.this.tags
+  task_role_arn            = aws_iam_role.task.arn
+
+  dynamic "volume" {
+    for_each = local.volumes
+
+    content {
+      name = volume.key
+
+      dynamic "efs_volume_configuration" {
+        for_each = length(volume.value.efs_volume) > 0 ? tomap({ "1" = jsondecode(volume.value.efs_volume) }) : tomap({})
+
+        content {
+          file_system_id          = efs_volume_configuration.value.file_system_id
+          root_directory          = efs_volume_configuration.value.root_directory
+          transit_encryption      = "ENABLED"
+          transit_encryption_port = 2999
+        }
+      }
+    }
+  }
+}
+
+resource "aws_iam_role" "task" {
+  name               = "task-${local.resource_name}"
+  assume_role_policy = data.aws_iam_policy_document.task_assume.json
+}
+
+data "aws_iam_policy_document" "task_assume" {
+  statement {
+    effect  = "Allow"
+    actions = ["sts:AssumeRole"]
+
+    principals {
+      type        = "Service"
+      identifiers = ["ecs-tasks.amazonaws.com"]
+    }
+  }
+}
+
+resource "aws_iam_role_policy" "task" {
+  role   = aws_iam_role.task.id
+  name   = local.resource_name
+  policy = data.aws_iam_policy_document.task.json
+}
+
+data "aws_iam_policy_document" "task" {
+  statement {
+    sid       = "AllowSSH"
+    effect    = "Allow"
+    resources = ["*"]
+
+    actions = [
+      "ssmmessages:CreateControlChannel",
+      "ssmmessages:CreateDataChannel",
+      "ssmmessages:OpenControlChannel",
+      "ssmmessages:OpenDataChannel"
+    ]
+  }
+}

--- a/urls.tf
+++ b/urls.tf
@@ -1,0 +1,35 @@
+locals {
+  // Private and public URLs are shown in the Nullstone UI
+  // Typically, they are created through capabilities attached to the application
+  // If this module has URLs, add them here as list(string)
+  additional_private_urls = []
+  additional_public_urls = []
+
+  private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
+  public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)
+}
+
+locals {
+  uri_matcher = "^(?:(?P<scheme>[^:/?#]+):)?(?://(?P<authority>[^/?#]*))?"
+}
+
+locals {
+  authority_matcher = "^(?:(?P<user>[^@]*)@)?(?:(?P<host>[^:]*))(?:[:](?P<port>[\\d]*))?"
+  // These tests are here to verify the authority_matcher regex above
+  // To verify, uncomment the following lines and issue `echo 'local.tests' | terraform console`
+  /*
+  tests = tomap({
+    "nullstone.io" : regex(local.authority_matcher, "nullstone.io"),
+    "brad@nullstone.io" : regex(local.authority_matcher, "brad@nullstone.io"),
+    "brad:password@nullstone.io" : regex(local.authority_matcher, "brad:password@nullstone.io"),
+    "nullstone.io:9000" : regex(local.authority_matcher, "nullstone.io:9000"),
+    "brad@nullstone.io:9000" : regex(local.authority_matcher, "brad@nullstone.io:9000"),
+    "brad:password@nullstone.io:9000" : regex(local.authority_matcher, "brad:password@nullstone.io:9000"),
+  })
+  */
+}
+
+locals {
+  private_hosts = [for url in local.private_urls : lookup(regex(local.authority_matcher, lookup(regex(local.uri_matcher, url), "authority")), "host")]
+  public_hosts  = [for url in local.public_urls : lookup(regex(local.authority_matcher, lookup(regex(local.uri_matcher, url), "authority")), "host")]
+}

--- a/urls.tf
+++ b/urls.tf
@@ -3,7 +3,7 @@ locals {
   // Typically, they are created through capabilities attached to the application
   // If this module has URLs, add them here as list(string)
   additional_private_urls = []
-  additional_public_urls = []
+  additional_public_urls  = []
 
   private_urls = concat([for url in try(local.capabilities.private_urls, []) : url["url"]], local.additional_private_urls)
   public_urls  = concat([for url in try(local.capabilities.public_urls, []) : url["url"]], local.additional_public_urls)

--- a/variables.tf
+++ b/variables.tf
@@ -1,0 +1,31 @@
+variable "service_cpu" {
+  type        = number
+  default     = 256
+  description = <<EOF
+The amount of CPU units to reserve for the service.
+1024 CPU units is roughly equivalent to 1 vCPU.
+This means the default of 256 CPU units is roughly .25 vCPUs.
+A vCPU is a virtualization of a physical CPU.
+EOF
+}
+
+variable "service_memory" {
+  type        = number
+  default     = 512
+  description = <<EOF
+The amount of memory to reserve and cap the service.
+If the service exceeds this amount, the service will be killed with exit code 127 representing "Out-of-memory".
+Memory is measured in MiB, or megabytes.
+This means the default is 512 MiB or 0.5 GiB.
+EOF
+}
+
+variable "service_env_vars" {
+  type        = map(string)
+  default     = {}
+  description = <<EOF
+The environment variables to inject into the service.
+These are typically used to configure a service per environment.
+It is dangerous to put sensitive information in this variable because they are not protected and could be unintentionally exposed.
+EOF
+}

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,0 +1,6 @@
+locals {
+  cap_mount_points = lookup(local.capabilities, "mount_points", [])
+
+  mount_points = [for mp in local.cap_mount_points : { sourceVolume = mp.name, containerPath = mp.path }]
+  volumes      = { for mp in local.cap_mount_points : mp.name => { efs_volume = lookup(mp, "efs_volume", "") } }
+}

--- a/volumes.tf
+++ b/volumes.tf
@@ -1,6 +1,8 @@
 locals {
   cap_mount_points = lookup(local.capabilities, "mount_points", [])
 
+  // See https://docs.aws.amazon.com/AmazonECS/latest/developerguide/bind-mounts.html
+
   mount_points = [for mp in local.cap_mount_points : { sourceVolume = mp.name, containerPath = mp.path }]
-  volumes      = { for mp in local.cap_mount_points : mp.name => { efs_volume = lookup(mp, "efs_volume", "") } }
+  volumes      = { for mp in local.cap_mount_points : mp.name => { host_path = lookup(mp, "host_path", ""), efs_volume = lookup(mp, "efs_volume", "") } }
 }


### PR DESCRIPTION
This is a draft of a nullstone app module `AWS ECS Task`.

This module provides the same method of push+deploy through the CLI as other container apps.
See https://github.com/nullstone-io/nullstone/pull/83 for CLI support.
- `nullstone push` - Pushes docker image into ECR
- `nullstone deploy` - Creates deploy record, registers new ECS task definition, deregisters previous ECS task definition

This module is almost identical to `AWS Fargate Service`; however, does have minor differences since it's only a task:
- `service_name` output is `""` to indicate there is no service
- No `service_port`, `service_count` variable since there is no service
- Load balancer capabilities will do nothing to the ecs task.
- Additional support for host-based volume mounts. (This enables support for https://github.com/nullstone-modules/aws-ecs-docker-sock capability module that automatically mounts the ECS Instance docker daemon into the container)
