### PR TITLE
Added cluster-namespace connection

### DIFF
--- a/cluster.tf
+++ b/cluster.tf
@@ -1,24 +1,18 @@
-data "ns_connection" "cluster" {
-  name     = "cluster"
-  type     = "cluster/aws-ecs"
-  contract = "cluster/aws/ecs:ec2"
+data "ns_connection" "cluster_namespace" {
+  name     = "cluster-namespace"
+  contract = "cluster-namespace/aws/ecs:*"
 }
 
-data "ns_connection" "network" {
-  name     = "network"
-  type     = "network/aws"
-  contract = "network/aws/vpc"
-  via      = data.ns_connection.cluster.name
+data "ns_connection" "cluster" {
+  name     = "cluster"
+  contract = "cluster/aws/ecs:ec2"
+  via      = data.ns_connection.cluster_namespace.name
 }
 
 locals {
-  vpc_id         = data.ns_connection.network.outputs.vpc_id
-  private_cidrs  = data.ns_connection.network.outputs.private_cidrs
-  public_cidrs   = data.ns_connection.network.outputs.public_cidrs
-  cluster_name   = data.ns_connection.cluster.outputs.cluster_name
-  deployers_name = data.ns_connection.cluster.outputs.deployers_name
-}
-
-data "aws_ecs_cluster" "cluster" {
-  cluster_name = local.cluster_name
+  service_domain       = data.ns_connection.cluster_namespace.outputs.namespace
+  service_discovery_id = data.ns_connection.cluster_namespace.outputs.service_discovery_id
+  cluster_arn          = data.ns_connection.cluster.outputs.cluster_arn
+  cluster_name         = data.ns_connection.cluster.outputs.cluster_name
+  deployers_name       = data.ns_connection.cluster.outputs.deployers_name
 }

--- a/network.tf
+++ b/network.tf
@@ -1,0 +1,12 @@
+data "ns_connection" "network" {
+  name     = "network"
+  contract = "network/aws/vpc"
+  via      = "${data.ns_connection.cluster_namespace.name}/${data.ns_connection.cluster.name}"
+}
+
+locals {
+  vpc_id             = data.ns_connection.network.outputs.vpc_id
+  private_cidrs      = data.ns_connection.network.outputs.private_cidrs
+  public_cidrs       = data.ns_connection.network.outputs.public_cidrs
+  private_subnet_ids = data.ns_connection.network.outputs.private_subnet_ids
+}


### PR DESCRIPTION
Added `cluster-namespace` connection that replaces the `cluster` required connection.
The `cluster` connection is now accessible `via` the `cluster-namespace`.

I don't think anybody outside of Nullstone is using this module.
We can likely publish this and immediately upgrade our own apps. (`enigma-builder`)

## TODO
- [x] Merge https://github.com/nullstone-io/deployment-sdk/pull/15
- [x] Upgrade enigma-builder with new deployment-sdk